### PR TITLE
Set default layer to mapbox satellite

### DIFF
--- a/web/modules/custom/farm_nfa/js/farmOS.map.behaviors.farm_nfa_layerswitcher_sidebar.js
+++ b/web/modules/custom/farm_nfa/js/farmOS.map.behaviors.farm_nfa_layerswitcher_sidebar.js
@@ -3,13 +3,21 @@
     attach: function (instance) {
       // opening layer switcher side bar by default
       window.onload = () => {
-        const sideBar = document.querySelectorAll('button[role="tab"]');
-        if (sideBar.length > 0) {
-          sideBar.forEach((element) => {
-            element.click();
-          });
+        const sideBar = document.querySelector('button[role="tab"]');
+        if (sideBar) {
+          sideBar.click();
+          this.setDefaultBaseLayer();
         }
       };
+    },
+    setDefaultBaseLayer: function () {
+      const baseLayerOptions = document.querySelectorAll('.layer-switcher-base-group .layer');
+      baseLayerOptions?.forEach((layer) => {
+        if (layer.innerText.includes('Mapbox Satellite')) {
+          const radioButton = layer.querySelector('input[type="radio"]');
+          radioButton.click();
+        }
+      });
     }
   }
 }())


### PR DESCRIPTION
added default layer setting to "mapbox satellite" instead of "OpenStreetMaps"

demo:



https://github.com/National-Forestry-Authority/forests/assets/58719389/beddbbb6-5f5e-420f-9f67-d04739d7a7ef





